### PR TITLE
Enable using plugin in a library project

### DIFF
--- a/android-aptlibs-gradle-plugin/src/main/groovy/com/evilduck/aptlibs/AptlibsPlugin.groovy
+++ b/android-aptlibs-gradle-plugin/src/main/groovy/com/evilduck/aptlibs/AptlibsPlugin.groovy
@@ -32,9 +32,9 @@ public class AptlibsPlugin implements Plugin<Project> {
     public void apply(Project project) {
         this.project = project
         def variants = null;
-        if (project.plugins.findPlugin("com.android.application")) {
+        if (project.plugins.findPlugin("com.android.application") || project.plugins.findPlugin("android")) {
             variants = "applicationVariants";
-        } else if (project.plugins.findPlugin("com.android.library")) {
+        } else if (project.plugins.findPlugin("com.android.library") || project.plugins.findPlugin("android-library")) {
             variants = "libraryVariants";
         } else {
             throw new ProjectConfigurationException("The com.android.application or com.android.library plugin must be applied to the project", null)

--- a/android-aptlibs-gradle-plugin/src/main/groovy/com/evilduck/aptlibs/AptlibsPlugin.groovy
+++ b/android-aptlibs-gradle-plugin/src/main/groovy/com/evilduck/aptlibs/AptlibsPlugin.groovy
@@ -20,6 +20,7 @@ package com.evilduck.aptlibs
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.internal.project.ProjectInternal
 
 public class AptlibsPlugin implements Plugin<Project> {
@@ -30,14 +31,20 @@ public class AptlibsPlugin implements Plugin<Project> {
 
     public void apply(Project project) {
         this.project = project
-
-        project.apply plugin: 'android'
+        def variants = null;
+        if (project.plugins.findPlugin("com.android.application")) {
+            variants = "applicationVariants";
+        } else if (project.plugins.findPlugin("com.android.library")) {
+            variants = "libraryVariants";
+        } else {
+            throw new ProjectConfigurationException("The com.android.application or com.android.library plugin must be applied to the project", null)
+        }
         aptlibsExt = project.extensions.create("aptlibs", AptlibsExtension, (ProjectInternal) project)
 
         project.afterEvaluate {
             setupDefaultAptConfigs()
         }
-        modifyJavaCompilerArguments()
+        modifyJavaCompilerArguments(variants)
     }
 
     def setupDefaultAptConfigs() {
@@ -68,8 +75,8 @@ public class AptlibsPlugin implements Plugin<Project> {
         }
     }
 
-    def modifyJavaCompilerArguments() {
-        project.android.applicationVariants.all { variant ->
+    def modifyJavaCompilerArguments(def variants) {
+        project.android[variants].all { variant ->
             def aptOutput = project.file("$project.buildDir/generated/source/$aptlibsExt.aptDir/$variant.dirName")
             variant.addJavaSourceFoldersToModel(aptOutput)
 


### PR DESCRIPTION
With this fix, users will be able to use plugin android, android-library, com.android.application or com.android.library.
